### PR TITLE
Use latest crx instead of temporary crx3-ahwayakchih

### DIFF
--- a/lib/routes/applicationize.js
+++ b/lib/routes/applicationize.js
@@ -13,9 +13,7 @@ var requestThunk = thunkify(request);
 var createCertificate = thunkify(pem.createCertificate);
 
 // CRX packaging module, instantiated with the `new` keyword
-// Temporarily use 'crx3-ahwayakchih' package until 'crx' gets the CRX3 support merged
-// https://github.com/oncletom/crx/pull/98
-var Extension = require('crx3-ahwayakchih');
+var Extension = require('crx');
 
 // POST /generate
 module.exports = function* () {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "cheerio": "0.19.0",
+    "crx3": "^5.0.1",
     "crx3-ahwayakchih": "^4.0.1",
     "fs-extra": "^7.0.1",
     "koa": "1.1.2",


### PR DESCRIPTION
- We were using crx3-ahwayakchih temporarily as the fix, since crx didn't supported crx3
- crx merged the PR which provides crx3 support https://github.com/oncletom/crx/pull/98
- Migrating over to use latest crx
